### PR TITLE
Upgrade to fbthrift 31.0 (and fix some docs).

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ document.
 
 Once homebrew is installed, simply run:
 
-    brew tap facebook/fb-homebrew-tap
+    brew tap facebook/fb-homebrew-tap https://github.com/facebook/fb-homebrew-tap
 
 Some of these formulae may require OS X 10.10 (Yosemite) or higher.
 
@@ -43,7 +43,7 @@ We use GitHub's [issue tracker][issue] for bug reports or feature requests.
 To do development on these formulae, first fork the repository on GitHub. Add
 your fork as a remote to your local clone:
 
-    cd $(brew --prefix)/Library/Taps/facebook/fb-homebrew-tap
+    cd $(brew --prefix)/Library/Taps/facebook/homebrew-fb-homebrew-tap
     git remote add me git@github.com:YOUR_GITHUB_USERNAME/fb-homebrew-tap.git
     git fetch me
 

--- a/fbthrift-compiler.rb
+++ b/fbthrift-compiler.rb
@@ -1,9 +1,9 @@
 class FbthriftCompiler < Formula
   desc "IDL compiler from Facebook's Thrift, an RPC system"
   homepage "https://github.com/facebook/fbthrift"
-  url "https://github.com/facebook/fbthrift/archive/v0.28.0.tar.gz"
-  version "28.0"
-  sha256 "1aa577d313c24950be1f0bb9681c4c959ce010a7ba298870c3f9a5b54c6cdc61"
+  url "https://github.com/facebook/fbthrift/archive/v0.31.0.tar.gz"
+  version "31.0"
+  sha256 "1910b85e808e1db92668af36656fe68e7bc780345aee6a5985bd193d5e8a2f4a"
 
   head "https://github.com/facebook/fbthrift.git"
 


### PR DESCRIPTION
Motivated by the need to pull in https://github.com/facebook/fbthrift/commit/a3b3c9e9df9dcc51f75ea8df5615f1f962e633b5 "add switch to skip VALUE_TO_NAME map for enums in java."

Ran end-to-end tests locally to verify that `skip_java_name_map` **is not** honored by fbthrift-complier version 28.0 and **is** honored by the fbthrift-compiler version 31.0 defined in this pull request.

While working on this, ran into some doc errors. Should we move the repo to something of the form `facebook/homebrew-*` or just accept the usability weirdness?